### PR TITLE
Fix typo in points and transformations

### DIFF
--- a/docs/user_guide/points_and_transformations.mdx
+++ b/docs/user_guide/points_and_transformations.mdx
@@ -55,7 +55,7 @@ point. In particular:
 
 ```rust
 let t = Isometry2::new(Vector2::new(1.0, 1.0), f32::consts::PI);
-let p = Point2::new(1.0, 0.0); // Will be affected by te rotation and the translation.
+let p = Point2::new(1.0, 0.0); // Will be affected by the rotation and the translation.
 let v = Vector2::x();          // Will *not* be affected by the translation.
 
 assert_relative_eq!(t * p, Point2::new(-1.0 + 1.0, 1.0));


### PR DESCRIPTION
te → the