### PR TITLE
doc fix: `.inverse` -> `.try_inverse`

### DIFF
--- a/docs/user_guide/decompositions_and_lapack.mdx
+++ b/docs/user_guide/decompositions_and_lapack.mdx
@@ -95,7 +95,7 @@ Method             | Effect
 `.r()`             | Retrieves the upper-triangular matrix $R$ part of the decomposition.
 `.q_tr_mul(rhs)`   | Overwrites `rhs` with the result of `self.q() * rhs`. This is much more efficient than computing $Q$ explicitly. |
 `.is_invertible()` | Determines if the decomposed matrix is invertible. |
-`.try_inverse`     | Computes the inverse of the decomposed matrix.
+`.try_inverse()`   | Computes the inverse of the decomposed matrix.
 `.solve(b)`        | Solves the system $Ax = b$ where $A$ is represented by `self` and $x$ the unknown. |
 `.solve_mut(b)`    | Overwrites `b` with the solution of the system $Ax = b$ where `A` is represented by `self` and $x$ the unknown. |
 `.unpack()`        | Consumes `self` to return the two factors $(Q, R)$ of this decomposition. |

--- a/docs/user_guide/decompositions_and_lapack.mdx
+++ b/docs/user_guide/decompositions_and_lapack.mdx
@@ -95,7 +95,7 @@ Method             | Effect
 `.r()`             | Retrieves the upper-triangular matrix $R$ part of the decomposition.
 `.q_tr_mul(rhs)`   | Overwrites `rhs` with the result of `self.q() * rhs`. This is much more efficient than computing $Q$ explicitly. |
 `.is_invertible()` | Determines if the decomposed matrix is invertible. |
-`.inverse()`       | Computes the inverse of the decomposed matrix.
+`.try_inverse`     | Computes the inverse of the decomposed matrix.
 `.solve(b)`        | Solves the system $Ax = b$ where $A$ is represented by `self` and $x$ the unknown. |
 `.solve_mut(b)`    | Overwrites `b` with the solution of the system $Ax = b$ where `A` is represented by `self` and $x$ the unknown. |
 `.unpack()`        | Consumes `self` to return the two factors $(Q, R)$ of this decomposition. |
@@ -133,7 +133,7 @@ Method                   | Effect
 `.u()`                   | Retrieves the upper-triangular matrix $U$ part of the decomposition.
 `.p()`                   | Computes the explicitly permutation matrix $P$ that made the decomposition possible.
 `.is_invertible()`       | Determines if the decomposed matrix is invertible. |
-`.inverse()`             | Computes the inverse of the decomposed matrix.
+`.try_inverse()`         | Computes the inverse of the decomposed matrix.
 `.determinant()`         | Computes the determinant of the decomposed matrix.
 `.solve(b)`              | Solves the system $Ax = b$ where $A$ is represented by `self` and $x$ the unknown. |
 `.solve_mut(b)`          | Overwrites `b` with the solution of the system $Ax = b$ where $A$ is represented by `self` and $x$ the unknown. |


### PR DESCRIPTION
Doc fix to match method names:

- [`.lu().try_inverse`](https://github.com/dimforge/nalgebra/blob/1576a1517ad652db5bfa1bb9071eeadc699b4328/src/linalg/lu.rs#L265)
- [`.qr().try_inverse`](https://github.com/dimforge/nalgebra/blob/1576a1517ad652db5bfa1bb9071eeadc699b4328/src/linalg/qr.rs#L261)

([Cholesky is just "`inverse`"](https://github.com/dimforge/nalgebra/blob/1576a1517ad652db5bfa1bb9071eeadc699b4328/src/linalg/cholesky.rs#L146))