### PR TITLE
Fixing tiny typo on landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,7 +48,7 @@ const features = [
     ),
 },
 {
-    title: <>nalgebra-sparse, for sparce matrices</>,
+    title: <>nalgebra-sparse, for sparse matrices</>,
     imageUrl: 'img/sparse_matrix.svg',
     description: (
         <>


### PR DESCRIPTION
"sparce -> sparse"