### PR TITLE
Rename slice to view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+nalgebra.org
+============
+
+This is the repository for [nalgebra.org](https://www.nalgebra.org).
+
+## Working locally
+To build, install the [yarn package manager](https://yarnpkg.com/) and run
+```
+yarn install
+```
+to install the required dependencies, and
+```
+yarn start
+```
+to serve the website locally.
+
+### Troubleshooting
+
+If you get an error like
+```
+at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3)
+{
+  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
+  library: 'digital envelope routines',
+  reason: 'unsupported',
+  code: 'ERR_OSSL_EVP_UNSUPPORTED'
+}
+```
+you might be able to work around it with the following environment variable:
+```
+export NODE_OPTIONS=--openssl-legacy-provider
+```

--- a/docs/user_guide/quick_reference.mdx.old
+++ b/docs/user_guide/quick_reference.mdx.old
@@ -58,20 +58,20 @@ Serialization with [serde](https://serde.rs) can be enabled by enabling the
 
 <br/>
 
-`MatrixSlice1<T> .. MatrixSlice6<T>`, `MatrixSlice<T, D, D>`     <span style={{float:'right'}}>Statically-sized square matrix slice.</span><br/>
-`MatrixSlice1x2<T> .. MatrixSlice6x5<T>`, `MatrixSlice<T, R, C>` <span style={{float:'right'}}>Statically-sized rectangular matrix slice.</span><br/>
-`MatrixSlice1xX<T> .. MatrixSlice6xX<T>`                         <span style={{float:'right'}}>Rectangular matrix slice with a dynamic number of columns.</span><br/>
-`MatrixSliceXx1<T> .. MatrixSliceXx6<T>`                         <span style={{float:'right'}}>Rectangular matrix slice with a dynamic number of rows.</span><br/>
-`DMatrixSlice<T>`                                                <span style={{float:'right'}}>Dynamically-sized matrix slice.</span><br/>
+`MatrixView1<T> .. MatrixView6<T>`, `MatrixView<T, D, D>`     <span style={{float:'right'}}>Statically-sized square matrix view.</span><br/>
+`MatrixView1x2<T> .. MatrixView6x5<T>`, `MatrixView<T, R, C>` <span style={{float:'right'}}>Statically-sized rectangular matrix view.</span><br/>
+`MatrixView1xX<T> .. MatrixView6xX<T>`                         <span style={{float:'right'}}>Rectangular matrix view with a dynamic number of columns.</span><br/>
+`MatrixViewXx1<T> .. MatrixViewXx6<T>`                         <span style={{float:'right'}}>Rectangular matrix view with a dynamic number of rows.</span><br/>
+`DMatrixView<T>`                                                <span style={{float:'right'}}>Dynamically-sized matrix view.</span><br/>
 
-Add `Mut` before the dimension numbers for mutable slice types, e.g., `MatrixSliceMut1x2<T>`, `DMatrixSliceMut<T>`.
+Add `Mut` before the dimension numbers for mutable view types, e.g., `MatrixViewMut1x2<T>`, `DMatrixViewMut<T>`.
 
 <br/>
 
-`VectorSlice1<T> .. VectorSlice6<N>`, `VectorSlice<N, D>` <span style={{float:'right'}}>Statically-sized column vector slice.</span><br/>
-`DVectorSlice<N>`                                         <span style={{float:'right'}}>Dynamically-sized column vector slice.</span><br/>
+`VectorView1<T> .. VectorView6<N>`, `VectorView<N, D>` <span style={{float:'right'}}>Statically-sized column vector view.</span><br/>
+`DVectorView<N>`                                         <span style={{float:'right'}}>Dynamically-sized column vector view.</span><br/>
 
-Add `Mut` before the dimension numbers for mutable slice types, e.g., `VectorSliceMut3<N>`, `DVectorSliceMut<N>`.
+Add `Mut` before the dimension numbers for mutable view types, e.g., `VectorViewMut3<N>`, `DVectorViewMut<N>`.
 
 <br/>
 
@@ -129,7 +129,7 @@ compile-time of the matrix being created.
 `.shape()`   <span style={{float:'right'}}>The number of rows and columns.</span><br/>
 `.nrows()`   <span style={{float:'right'}}>The number of rows.</span><br/>
 `.ncols()`   <span style={{float:'right'}}>The number of columns.</span><br/>
-`.strides()` <span style={{float:'right'}}>Number of skipped original rows/columns in-between each row/column of a slice.</span><br/>
+`.strides()` <span style={{float:'right'}}>Number of skipped original rows/columns in-between each row/column of a view.</span><br/>
 
 <br/>
 
@@ -210,12 +210,12 @@ compile-time of the matrix being created.
 
 ---------
 
-### Slicing
-Slice are references to sub-matrices. They do not own their data and cannot be
+### Views
+Views are references to sub-matrices. They do not own their data and cannot be
 converted to arrays as their data buffer may not be contiguous in memory.
-Mutable slices are obtained using the same methods suffixed by `_mut`, e.g.,
+Mutable views are obtained using the same methods suffixed by `_mut`, e.g.,
 `.row_mut(i)`. They can also be constructed from a data array `&[N]` using the
-constructors of matrix slice type aliases, e.g., `MatrixSlice3::from_slice(data)`.
+constructors of matrix view type aliases, e.g., `MatrixView3::from_slice(data)`.
 
 
 `.row(i)`                             <span style={{float:'right'}}>A matrix row.</span><br />
@@ -234,10 +234,10 @@ constructors of matrix slice type aliases, e.g., `MatrixSlice3::from_slice(data)
 
 <br/>
 
-`.slice((i, j), (nrows, ncols))`                           <span style={{float:'right'}}>Consecutive rows and columns.</span><br />
-`.slice_with_steps((i, j), (nrows, ncols), (rstep, cstep)` <span style={{float:'right'}}>Non consecutive rows and columns.</span><br />
-`.fixed_slice::<R, C>((i, j))`                             <span style={{float:'right'}}>Compile-time number of consecutive rows and columns.</span><br />
-`.fixed_slice_with_steps::<R, C>((i, j), (rstep, cstep))`  <span style={{float:'right'}}>Compile-time number of non consecutive rows and columns.</span><br />
+`.view((i, j), (nrows, ncols))`                           <span style={{float:'right'}}>Consecutive rows and columns.</span><br />
+`.view_with_steps((i, j), (nrows, ncols), (rstep, cstep)` <span style={{float:'right'}}>Non-consecutive rows and columns.</span><br />
+`.fixed_view::<R, C>((i, j))`                             <span style={{float:'right'}}>Compile-time number of consecutive rows and columns.</span><br />
+`.fixed_view_with_steps::<R, C>((i, j), (rstep, cstep))`  <span style={{float:'right'}}>Compile-time number of non consecutive rows and columns.</span><br />
 
 -----
 
@@ -476,6 +476,6 @@ instead.
 ### Implementors
 `MatrixArray<...>`      <span style={{float:'right'}}>A stack-allocated owned data storage.</span><br/>
 `MatrixVec<...>`        <span style={{float:'right'}}>A heap-allocated owned data storage.</span><br/>
-`MatrixSlice<...>`      <span style={{float:'right'}}>A non-mutable reference to a piece of another data storage.</span><br/>
-`MatrixSliceMut<...>`   <span style={{float:'right'}}>A mutable reference to a piece of another data storage.</span><br/>
+`MatrixView<...>`      <span style={{float:'right'}}>A non-mutable reference to a piece of another data storage.</span><br/>
+`MatrixViewMut<...>`   <span style={{float:'right'}}>A mutable reference to a piece of another data storage.</span><br/>
 `DefaultAllocator<...>` <span style={{float:'right'}}>Allocates `MatrixArray` for statically sized matrices, and `MatrixVec` otherwise.</span><br/>

--- a/docs/user_guide/vectors_and_matrices.mdx
+++ b/docs/user_guide/vectors_and_matrices.mdx
@@ -69,7 +69,7 @@ type Matrix2x3f = SMatrix<f32, 2, 3>;
 // two rows using 64-bit floats.
 //
 // The `OMatrix` alias is a matrix that owns its data (as opposed to
-// matrix slices which borrow their data from another matrix).
+// matrix view which borrow their data from another matrix).
 type Matrix2xXf64 = OMatrix<f64, U2, Dynamic>;
 
 // Dynamically sized and dynamically allocated matrix with
@@ -358,29 +358,29 @@ Because types like `Vector3` are column vectors, i.e., matrices with dimension 3
 `.set_column(...)`. For setting a row with `.set_row(...)` it is necessary to use a row vector. For example `RowVector4`
 is a 4D row vector, i.e., a matrix with dimensions 4×1.
 
-## Matrix slicing
-Matrix (and vector) slicing allows you to take a reference to a part of any
-matrix.  Slicing a matrix does not perform any copy, move, or allocation of the
+## Matrix views
+Matrix (and vector) views allow you to take a reference to a part of any
+matrix. A view does not perform any copy, move, or allocation of the
 original matrix data. Instead, it stores a pointer to that data together with
-some metadata about the slice size and strides. Note that taking a slice of a
-matrix slice is allowed!
+some metadata about the view size and strides. Note that taking a view of a
+matrix view is allowed!
 
-Because a matrix slice is also just special-case of the generic `Matrix<T, R, C, S>`
-type, it can usually be used just like a plain, non-slice matrix besides three exceptions:
+Because a matrix view is also just a special case of the generic `Matrix<T, R, C, S>`
+type, it can usually be used just like a plain, non-view matrix besides three exceptions:
 
-1. Methods that require a `&mut self` cannot be called on non-mutable slices.
-2. Matrix slices cannot be created out of thin air using the methods shown in
+1. Methods that require a `&mut self` cannot be called on non-mutable views.
+2. Matrix views cannot be created out of thin air using the methods shown in
    the [Matrix construction](#matrix_construction) section. One must already
-   have a instance of a matrix or another slice and use one of the dedicated
+   have an instance of a matrix or another view and use one of the dedicated
    methods shown thereafter.
-3. Assignment operators do not work on any kind of slice, i.e., one cannot
-   write `a *= b` if `a` even if `a` is a mutable matrix slice.
+3. Assignment operators do not work on any kind of view, i.e., one cannot
+   write `a *= b` even if `a` is a mutable matrix view.
 
-There are three variations of matrix slicing methods. Mutable slices follow the
+There are three variations of matrix view methods. Mutable views follow the
 same semantics, except that the method names end with `_mut`:
 
-* **"Fixed" slices:** slices with numbers of rows and columns known at
-  compile-time. The name of the corresponding slicing methods usually start
+* **"Fixed" views:** views with numbers of rows and columns known at
+  compile-time. The name of the corresponding view methods usually start
   with the prefix `fixed_`.
 
 Method                             | Description
@@ -389,69 +389,69 @@ Method                             | Description
 `.column(i)`                       | Reference to the i-th column of `self`. |
 `.fixed_rows::<D>(i)`              | Reference to the submatrix with `D` consecutive rows of `self`, starting with the i-th. `D` must be an integer. |
 `.fixed_columns::<D>(i)`           | Reference to the submatrix with `D` consecutive columns of `self`, starting with the i-th. `D` must be an integer. |
-`.fixed_slice::<R, C>(irow, icol)` | Reference to the submatrix with `R` consecutive rows and `C` consecutive columns, starting with the `irow`-th row and `icol`-th column. `R` and `C` are integers. |
+`.fixed_view::<R, C>(irow, icol)` | Reference to the submatrix with `R` consecutive rows and `C` consecutive columns, starting with the `irow`-th row and `icol`-th column. `R` and `C` are integers. |
 
 <div style={{textAlign: 'center'}}>
 
-![Fixed slices](/img/fixed_slices.svg)
+![Fixed views](/img/fixed_views.svg)
 
 </div>
 
 ----
 
 
-* **"Dynamic" slices:** slices with numbers of rows and columns known at
+* **"Dynamic" views:** views with numbers of rows and columns known at
   run-time only.
 
 Method                 | Description
 -----------------------|------------
 `.rows(i, size)`       | Reference to `size` rows of `self`, starting with the i-th. |
 `.columns(i, size)`    | Reference to `size` columns of `self`, starting with the i-th. |
-`.slice(start, shape)` | Reference to the submatrix with `shape.0` rows and `shape.1` columns, starting with the `start.0`-th row and `start.1`-th column. `start` and `shape` are both tuples. |
+`.view(start, shape)` | Reference to the submatrix with `shape.0` rows and `shape.1` columns, starting with the `start.0`-th row and `start.1`-th column. `start` and `shape` are both tuples. |
 
 <div style={{textAlign: 'center'}}>
 
-![Dynamic slices](/img/dynamic_slices.svg)
+![Dynamic views](/img/dynamic_views.svg)
 
 </div>
 
 ----
 
-* **Slices with strides:** fixed or dynamic slices that reference
+* **Views with strides:** fixed or dynamic views that reference
   non-consecutive (but regularly spaced) rows and columns of the original
-  matrix. The name of the corresponding slicing methods end with `_with_step`.
+  matrix. The name of the corresponding view methods end with `_with_step`.
 
 Method                                         | Description
 -----------------------------------------------|------------
 `.fixed_rows_with_step::<D>(i, step)`          | Reference to `D` non-consecutive rows of `self`, starting with the i-th. `step` rows of `self` are skipped between each referenced row. |
 `.fixed_columns_with_step::<D>(i, step)`       | Reference to `D` non-consecutive columns of `self`, starting with the i-th. `step` columns of `self` are skipped between each referenced column. |
-`.fixed_slice_with_steps::<R, C>(start, step)` | Reference to `R` and `C` non-consecutive rows and columns, starting with the component `(start.0, start.1)`. `step.0` (resp. `step.1`) rows (resp. columns) are skipped between each referenced row (resp. column). |
+`.fixed_view_with_steps::<R, C>(start, step)` | Reference to `R` and `C` non-consecutive rows and columns, starting with the component `(start.0, start.1)`. `step.0` (resp. `step.1`) rows (resp. columns) are skipped between each referenced row (resp. column). |
 `.rows_with_step(i, size, step)`               | Reference to `size` rows of `self`, starting with the i-th. `step` rows are skipped between each referenced row. |
 `.columns_with_step(i, size, step)`            | Reference to `size` columns of `self`, starting with the i-th. `step` columns are skipped between each reference column. |
-`.slice_with_steps(start, shape, steps)`       | Reference to `shape.0` rows and `shape.1` columns, starting with the `(start.0, start.1)`-th component. `step.0` (resp. `step.1`) rows (resp. columns) are skipped between each referenced row (resp. column). |
+`.view_with_steps(start, shape, steps)`       | Reference to `shape.0` rows and `shape.1` columns, starting with the `(start.0, start.1)`-th component. `step.0` (resp. `step.1`) rows (resp. columns) are skipped between each referenced row (resp. column). |
 
 <div style={{textAlign: 'center'}}>
 
-![Slices with strides](/img/slices_with_strides.svg)
+![Views with strides](/img/views_with_strides.svg)
 
 </div>
 
 Note that the method `.clone_owned()` may be used to create a plain matrix from
-a slice, i.e., actually copying the referenced components into a new matrix
+a view, i.e., actually copying the referenced components into a new matrix
 structure that owns its data. Whether or not the result of this cloning is a
-dynamically- or statically-sized matrix depends on the kind of slice.
-Fixed slices will yield a statically-sized matrix while dynamic slices yield
+dynamically- or statically-sized matrix depends on the kind of view.
+Fixed views will yield a statically-sized matrix while dynamic views yield
 a dynamically-sized matrix.
 
 <div style={{textAlign: 'center'}}>
 
-![slice.clone_owned()](/img/slice_clone_owned.svg)
+![view.clone_owned()](/img/view_clone_owned.svg)
 
 </div>
 
 ## Matrix resizing
 The number of rows or columns of a matrix can be modified by adding or removing
-some of them. Similarly to [slicing](#matrix-slicing), two variants exist:
+some of them. Similarly to [views](#matrix-views), two variants exist:
 
 
 * **"Fixed resizing"** where the number of rows or columns to be removed or

--- a/static/img/dynamic_views.svg
+++ b/static/img/dynamic_views.svg
@@ -16,7 +16,7 @@
    id="svg5874"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="dynamic_slices.svg">
+   sodipodi:docname="dynamic_views.svg">
   <defs
      id="defs5876" />
   <sodipodi:namedview
@@ -828,6 +828,6 @@
          sodipodi:role="line"
          x="698.70758"
          y="212.28444"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392498px;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.slice((0, 1), (2, 2))</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392498px;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.view((0, 1), (2, 2))</tspan></text>
   </g>
 </svg>

--- a/static/img/fixed_views.svg
+++ b/static/img/fixed_views.svg
@@ -8,7 +8,7 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   sodipodi:docname="fixed_slices.svg"
+   sodipodi:docname="fixed_views.svg"
    inkscape:version="1.0.2 (394de47547, 2021-03-26)"
    version="1.1"
    id="svg10435"
@@ -939,7 +939,7 @@
          y="488.71869"
          x="28.594997"
          sodipodi:role="line"
-         id="tspan5283">.fixed_slice::&lt;2, 2&gt;(0, 1)</tspan></text>
+         id="tspan5283">.fixed_view::&lt;2, 2&gt;(0, 1)</tspan></text>
     <g
        transform="translate(-342.25969,-17.142857)"
        id="g5381">

--- a/static/img/view_clone_owned.svg
+++ b/static/img/view_clone_owned.svg
@@ -14,7 +14,7 @@
    id="svg7890"
    version="1.1"
    inkscape:version="1.0.2 (394de47547, 2021-03-26)"
-   sodipodi:docname="slice_clone_owned.svg">
+   sodipodi:docname="view_clone_owned.svg">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -121,7 +121,7 @@
          y="431.23727"
          x="240.7157"
          id="tspan10878"
-         sodipodi:role="line">.fixed_slice_with_step::&lt;2, 2&gt;((1, 0), (1, 2))</tspan></text>
+         sodipodi:role="line">.fixed_view_with_step::&lt;2, 2&gt;((1, 0), (1, 2))</tspan></text>
     <g
        id="g4535"
        transform="translate(12.857143,1.4336285)">
@@ -568,7 +568,7 @@
          id="tspan10938"
          x="240.7157"
          y="453.35913"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.slice_with_step((1, 0), (2, 2), (1, 2))</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.view_with_step((1, 0), (2, 2), (1, 2))</tspan></text>
     <g
        id="g4511"
        transform="translate(28.220445,8.6158407)">

--- a/static/img/views_with_strides.svg
+++ b/static/img/views_with_strides.svg
@@ -14,7 +14,7 @@
    id="svg7890"
    version="1.1"
    inkscape:version="1.0.2 (394de47547, 2021-03-26)"
-   sodipodi:docname="slices_with_strides.svg">
+   sodipodi:docname="views_with_strides.svg">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -1203,7 +1203,7 @@
          y="425.52298"
          x="240.7157"
          id="tspan10878"
-         sodipodi:role="line">.fixed_slice_with_step::&lt;2, 2&gt;((1, 0), (1, 2))</tspan></text>
+         sodipodi:role="line">.fixed_view_with_step::&lt;2, 2&gt;((1, 0), (1, 2))</tspan></text>
     <g
        id="g10880"
        transform="matrix(2.7800364,0,0,-2.7800364,-371.31236,2357.4277)"
@@ -1396,6 +1396,6 @@
          id="tspan10938"
          x="240.7157"
          y="449.76666"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.slice_with_step((1, 0), (2, 2), (1, 2))</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.1392px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#bd447f;fill-opacity:1">.view_with_step((1, 0), (2, 2), (1, 2))</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
This PR updates the user guide with the new "view" terminology that replaces the current "slice" terminology, in accordance with dimforge/nalgebra#1076 and complementing dimforge/nalgebra#1178.

I also took the liberty of adding a very basic `README.md` file with basic build instructions, as I didn't really know how to get it up and running without consulting @sebcrozet. Hopefully this makes it easier for others who like myself are also not well-versed in the `node.js` universe.