### PR TITLE
Change column-major to row-major for ArrayStorage

### DIFF
--- a/docs/user_guide/vectors_and_matrices.mdx
+++ b/docs/user_guide/vectors_and_matrices.mdx
@@ -82,7 +82,7 @@ type Matrix1000x3f = SMatrix<f32, 1000, 3>;
 
 Internally, dynamically- and statically-sized matrices do not use the same data
 storage type. While the former is always allocated on the heap using a `Vec`,
-the latter prefers static allocation indirectly using a column-major 2D array
+the latter prefers static allocation indirectly using a row-major 2D array
 `[[T; R]; C]` for better performances.
 
 


### PR DESCRIPTION
The docs stated incorrectly, that an SMatrix (which uses ArrayStorage) uses a column-major layout. However, it is row-major.